### PR TITLE
Added support for HTTP/2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "winternet-studio/oauth-php",
+    "name": "zorrodg/oauth-php",
     "description": "OAuth composer implementation from oauth-php library from Marc Worrell",
     "license": "MIT",
     "authors": [
@@ -10,10 +10,6 @@
         {
             "name": "Andres Zorro",
             "email": "zorrodg@gmail.com"
-        },
-        {
-            "name": "Allan Jensen",
-            "email": "info@winternet.no"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zorrodg/oauth-php",
+    "name": "winternet-studio/oauth-php",
     "description": "OAuth composer implementation from oauth-php library from Marc Worrell",
     "license": "MIT",
     "authors": [
@@ -10,6 +10,10 @@
         {
             "name": "Andres Zorro",
             "email": "zorrodg@gmail.com"
+        },
+        {
+            "name": "Allan Jensen",
+            "email": "info@winternet.no"
         }
     ],
     "require": {

--- a/src/OAuth1/OAuthRequester.php
+++ b/src/OAuth1/OAuthRequester.php
@@ -474,7 +474,7 @@ class OAuthRequester extends OAuthRequestSigner
 	
 		// first line of headers is the HTTP response code 
 		$http_line = array_shift($lines);
-		if (preg_match('@^HTTP/[0-9]\.[0-9] +([0-9]{3})@', $http_line, $matches))
+		if (preg_match('@^HTTP/[0-9]\.?[0-9]? +([0-9]{3})@', $http_line, $matches))  // added dot and minor version number to be optional in order to support eg. "HTTP/2 200"
 		{
 			$code = $matches[1];
 		}


### PR DESCRIPTION
Correctly parse the curl HTTP response code when it is eg. `HTTP/2 200`